### PR TITLE
Cache static read queries in-process to speed up page load

### DIFF
--- a/server/src/routes/regionRoutes.js
+++ b/server/src/routes/regionRoutes.js
@@ -1,7 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const regionsController = require('../controllers/regionsController');
+const cached = require('../utils/cache');
 
-router.get('/', regionsController.getRegionsByCountry);
+router.get('/', cached(regionsController.getRegionsByCountry));
 
 module.exports = router;

--- a/server/src/routes/runRoutes.js
+++ b/server/src/routes/runRoutes.js
@@ -1,7 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const runController = require('../controllers/runController');
+const cached = require('../utils/cache');
 
-router.get('/', runController.getRuns);
+router.get('/', cached(runController.getRuns));
 
 module.exports = router;

--- a/server/src/routes/skiAreaRoutes.js
+++ b/server/src/routes/skiAreaRoutes.js
@@ -3,9 +3,10 @@ const router = express.Router();
 const skiAreaController = require('../controllers/skiAreaController');
 const skiAreaNameController = require('../controllers/skiAreaNameController');
 const skiAreaWebsiteController = require('../controllers/skiAreaWebsiteController');
+const cached = require('../utils/cache');
 
-// All ski areas
-router.get('/', skiAreaController.getSkiAreas);
+// All ski areas (cached: heavy aggregate over a static dataset)
+router.get('/', cached(skiAreaController.getSkiAreas));
 
 // Names for a ski area based on id
 router.get('/:id/names', skiAreaNameController.getNamesBySkiAreaId);

--- a/server/src/utils/cache.js
+++ b/server/src/utils/cache.js
@@ -1,0 +1,52 @@
+// ponytail: in-proc cache keyed by URL. Data is static between seeds, so no TTL or
+// invalidation — just clear() on reseed. Swap for Redis only if the backend scales past one replica.
+const store = new Map();
+
+// Wrap a GET controller: serve cached JSON by full URL, otherwise run it and capture
+// the response. Only array payloads are cached, so 500s ({error}) and favorites are skipped.
+function cached(handler) {
+  return (req, res) => {
+    if (req.query.favorites === 'true') return handler(req, res); // per-user, mutable
+    const key = req.originalUrl;
+    if (store.has(key)) return res.json(store.get(key));
+
+    const sendJson = res.json.bind(res);
+    res.json = (body) => {
+      if (Array.isArray(body)) store.set(key, body);
+      return sendJson(body);
+    };
+    handler(req, res);
+  };
+}
+
+cached.clear = () => store.clear();
+
+module.exports = cached;
+
+// ponytail: self-check — `node src/utils/cache.js`. Verifies hit/miss, that errors
+// aren't cached, and that favorites bypass the cache entirely.
+if (require.main === module) {
+  const assert = require('assert');
+  cached.clear();
+  let calls = 0;
+  const handler = cached((req, res) => {
+    calls++;
+    if (req.query.fail) return res.status(500).json({ error: 'boom' });
+    res.json([req.originalUrl]);
+  });
+  const fakeRes = () => ({ status() { return this; }, json(b) { this.body = b; return b; } });
+
+  let r = fakeRes(); handler({ originalUrl: '/a', query: {} }, r);          // miss
+  handler({ originalUrl: '/a', query: {} }, r = fakeRes());                  // hit, handler not re-run
+  assert.strictEqual(calls, 1, 'second identical request should be served from cache');
+
+  handler({ originalUrl: '/b', query: { fail: 1 } }, fakeRes());            // error: not cached
+  handler({ originalUrl: '/b', query: { fail: 1 } }, fakeRes());            // runs again
+  assert.strictEqual(calls, 3, 'errors must not be cached');
+
+  handler({ originalUrl: '/c', query: { favorites: 'true' } }, fakeRes());
+  handler({ originalUrl: '/c', query: { favorites: 'true' } }, fakeRes());  // never cached
+  assert.strictEqual(calls, 5, 'favorites must bypass the cache');
+
+  console.log('cache.js self-check passed');
+}


### PR DESCRIPTION
The ski-areas mount query aggregates every area against all its runs (6 SUM(CASE) + COUNT DISTINCT + MAX, GROUP BY, ORDER BY VerticalM with no usable index), and auto-load-on-mount now runs it on every visit. Data is static between seeds, so wrap the ski-areas, runs, and regions GET handlers in an in-process URL-keyed cache: errors and favorites bypass it. Swap for Redis only if the backend scales past one replica.